### PR TITLE
Imcool2551

### DIFF
--- a/src/main/java/com/sososhopping/server/common/dto/user/response/store/CouponDto.java
+++ b/src/main/java/com/sososhopping/server/common/dto/user/response/store/CouponDto.java
@@ -1,0 +1,42 @@
+package com.sososhopping.server.common.dto.user.response.store;
+
+import com.sososhopping.server.entity.coupon.Coupon;
+import com.sososhopping.server.entity.coupon.FixCoupon;
+import com.sososhopping.server.entity.coupon.RateCoupon;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+public class CouponDto {
+
+    private Long couponId;
+    private String storeName;
+    private String couponName;
+    private Integer stockQuantity;
+    private String couponCode;
+    private Integer minimumOrderPrice;
+    private LocalDateTime startDate;
+    private LocalDateTime dueDate;
+    private String couponType;
+    private Integer fixAmount;
+    private BigDecimal rateAmount;
+
+    public CouponDto(Coupon coupon) {
+        couponId = coupon.getId();
+        storeName = coupon.getStoreName();
+        couponName = coupon.getCouponName();
+        stockQuantity = coupon.getStockQuantity();
+        couponCode = coupon.getCouponCode();
+        minimumOrderPrice = coupon.getMinimumOrderPrice();
+        startDate = coupon.getStartDate();
+        dueDate = coupon.getDueDate();
+        couponType = coupon.getCouponType();
+        if (coupon instanceof FixCoupon) {
+            fixAmount = ((FixCoupon) coupon).getFixAmount();
+        } else if (coupon instanceof RateCoupon) {
+            rateAmount = ((RateCoupon) coupon).getRateAmount();
+        }
+    }
+}

--- a/src/main/java/com/sososhopping/server/common/dto/user/response/store/ItemDto.java
+++ b/src/main/java/com/sososhopping/server/common/dto/user/response/store/ItemDto.java
@@ -1,0 +1,26 @@
+package com.sososhopping.server.common.dto.user.response.store;
+
+import com.sososhopping.server.entity.store.Item;
+import lombok.Getter;
+
+@Getter
+public class ItemDto {
+
+    private Long itemId;
+    private String name;
+    private String description;
+    private String purchaseUnit;
+    private String imgUrl;
+    private Integer price;
+    private Boolean saleStatus;
+
+    public ItemDto(Item item) {
+        itemId = item.getId();
+        name = item.getName();
+        description = item.getDescription();
+        purchaseUnit = item.getPurchaseUnit();
+        imgUrl = item.getImgUrl();
+        price = item.getPrice();
+        saleStatus = item.getSaleStatus();
+    }
+}

--- a/src/main/java/com/sososhopping/server/controller/user/coupon/UserCouponController.java
+++ b/src/main/java/com/sososhopping/server/controller/user/coupon/UserCouponController.java
@@ -1,0 +1,37 @@
+package com.sososhopping.server.controller.user.coupon;
+
+import com.sososhopping.server.common.dto.ApiResponse;
+import com.sososhopping.server.common.dto.user.response.store.CouponDto;
+import com.sososhopping.server.common.error.Api404Exception;
+import com.sososhopping.server.entity.store.Store;
+import com.sososhopping.server.repository.coupon.CouponRepository;
+import com.sososhopping.server.repository.store.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+public class UserCouponController {
+
+    private final StoreRepository storeRepository;
+
+    @GetMapping("/api/v1/stores/{storeId}/coupons")
+    public ApiResponse<CouponDto> getStoreCoupons(@PathVariable Long storeId) {
+
+        Store findStore = storeRepository
+                .findById(storeId)
+                .orElseThrow(() -> new Api404Exception("존재하지 않는 점포입니다"));
+
+        List<CouponDto> couponListDto = findStore.getCoupons()
+                .stream()
+                .map(coupon -> new CouponDto(coupon))
+                .collect(Collectors.toList());
+
+        return new ApiResponse<CouponDto>(couponListDto);
+    }
+}

--- a/src/main/java/com/sososhopping/server/controller/user/store/UserItemController.java
+++ b/src/main/java/com/sososhopping/server/controller/user/store/UserItemController.java
@@ -1,0 +1,38 @@
+package com.sososhopping.server.controller.user.store;
+
+import com.sososhopping.server.common.dto.ApiResponse;
+import com.sososhopping.server.common.dto.user.response.store.ItemDto;
+import com.sososhopping.server.common.error.Api404Exception;
+import com.sososhopping.server.entity.store.Item;
+import com.sososhopping.server.entity.store.Store;
+import com.sososhopping.server.repository.store.ItemRepository;
+import com.sososhopping.server.repository.store.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+public class UserItemController {
+
+    private final StoreRepository storeRepository;
+
+    @GetMapping("/api/v1/stores/{storeId}/items")
+    public ApiResponse<ItemDto> getStoreItems(@PathVariable Long storeId) {
+
+        Store findStore = storeRepository
+                .findById(storeId)
+                .orElseThrow(() -> new Api404Exception("존재하지 않는 점포입니다"));
+
+        List<ItemDto> itemDtoList = findStore.getItems()
+                .stream()
+                .map(item -> new ItemDto(item))
+                .collect(Collectors.toList());
+
+        return new ApiResponse<ItemDto>(itemDtoList);
+    }
+}

--- a/src/main/java/com/sososhopping/server/entity/coupon/Coupon.java
+++ b/src/main/java/com/sososhopping/server/entity/coupon/Coupon.java
@@ -2,10 +2,7 @@ package com.sososhopping.server.entity.coupon;
 
 import com.sososhopping.server.entity.BaseTimeEntity;
 import com.sososhopping.server.entity.store.Store;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
@@ -21,7 +18,6 @@ import static javax.persistence.FetchType.*;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public abstract class Coupon extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,30 +27,56 @@ public abstract class Coupon extends BaseTimeEntity {
     @NotNull
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "store_id")
-    private Store store;
+    protected Store store;
 
     @NotNull
-    private String storeName;
+    protected String storeName;
 
     @Column(name = "coupon_name")
-    private String couponName;
+    protected String couponName;
 
     @NotNull
-    private Integer stockQuantity;
+    protected Integer stockQuantity;
 
     @NotNull
     @Column(unique = true, columnDefinition = "char")
-    private String couponCode;
+    protected String couponCode;
 
     @NotNull
-    private Integer minimumOrderPrice;
+    protected Integer minimumOrderPrice;
 
     @NotNull
-    private LocalDateTime startDate;
+    protected LocalDateTime startDate;
 
     @NotNull
-    private LocalDateTime dueDate;
+    protected LocalDateTime dueDate;
+
+    @Column(name = "coupon_type", insertable = false, updatable = false)
+    protected String couponType;
+
+    public Coupon(
+            String storeName,
+            String couponName,
+            Integer stockQuantity,
+            String couponCode,
+            Integer minimumOrderPrice,
+            LocalDateTime startDate,
+            LocalDateTime dueDate
+    ) {
+        this.storeName = storeName;
+        this.couponName = couponName;
+        this.stockQuantity = stockQuantity;
+        this.couponCode = couponCode;
+        this.minimumOrderPrice = minimumOrderPrice;
+        this.startDate = startDate;
+        this.dueDate = dueDate;
+    }
 
     abstract protected int getDiscountPrice();
 
+    // 연관 관계 편의 메서드
+    public void setStore(Store store) {
+        this.store = store;
+        this.store.getCoupons().add(this);
+    }
 }

--- a/src/main/java/com/sososhopping/server/entity/coupon/FixCoupon.java
+++ b/src/main/java/com/sososhopping/server/entity/coupon/FixCoupon.java
@@ -1,10 +1,18 @@
 package com.sososhopping.server.entity.coupon;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
+import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @DiscriminatorValue("FIX")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FixCoupon extends Coupon {
 
     private Integer fixAmount;
@@ -12,5 +20,20 @@ public class FixCoupon extends Coupon {
     @Override
     protected int getDiscountPrice() {
         return fixAmount;
+    }
+
+    @Builder
+    public FixCoupon(
+            String storeName,
+            String couponName,
+            Integer stockQuantity,
+            String couponCode,
+            Integer minimumOrderPrice,
+            LocalDateTime startDate,
+            LocalDateTime dueDate,
+            Integer fixAmount
+    ) {
+        super(storeName, couponName, stockQuantity, couponCode, minimumOrderPrice, startDate, dueDate);
+        this.fixAmount = fixAmount;
     }
 }

--- a/src/main/java/com/sososhopping/server/entity/coupon/RateCoupon.java
+++ b/src/main/java/com/sososhopping/server/entity/coupon/RateCoupon.java
@@ -1,14 +1,37 @@
 package com.sososhopping.server.entity.coupon;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @DiscriminatorValue("RATE")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RateCoupon extends Coupon {
 
     private BigDecimal rateAmount;
+
+    @Builder
+    public RateCoupon(
+            String storeName,
+            String couponName,
+            Integer stockQuantity,
+            String couponCode,
+            Integer minimumOrderPrice,
+            LocalDateTime startDate,
+            LocalDateTime dueDate,
+            BigDecimal rateAmount
+    ) {
+        super(storeName, couponName, stockQuantity, couponCode, minimumOrderPrice, startDate, dueDate);
+        this.rateAmount = rateAmount;
+    }
 
     @Override
     protected int getDiscountPrice() {

--- a/src/main/java/com/sososhopping/server/entity/store/Item.java
+++ b/src/main/java/com/sososhopping/server/entity/store/Item.java
@@ -10,13 +10,16 @@ import javax.validation.constraints.NotNull;
 
 import static javax.persistence.FetchType.*;
 
+@Builder
 @Entity
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Item extends BaseTimeEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "item_id")
     private Long id;
 
@@ -42,27 +45,8 @@ public class Item extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TINYINT", length = 1)
     private Boolean saleStatus;
 
-    // 생성자 + 빌더
-    @Builder
-    public Item(Store store,
-                String name,
-                String description,
-                String purchaseUnit,
-                String imgUrl,
-                Integer price,
-                Boolean saleStatus
-    ) {
-        setStore(store);
-        this.name = name;
-        this.description = description;
-        this.purchaseUnit = purchaseUnit;
-        this.imgUrl = imgUrl;
-        this.price = price;
-        this.saleStatus = saleStatus;
-    }
-
     // 연관 관계 편의 메서드
-    private void setStore(Store store) {
+    public void setStore(Store store) {
         this.store = store;
         this.store.getItems().add(this);
     }

--- a/src/main/java/com/sososhopping/server/entity/store/Store.java
+++ b/src/main/java/com/sososhopping/server/entity/store/Store.java
@@ -19,10 +19,12 @@ import java.util.List;
 import static javax.persistence.CascadeType.*;
 import static javax.persistence.FetchType.*;
 
+@Builder
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Store extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -111,7 +113,7 @@ public class Store extends BaseTimeEntity {
     @OneToMany(mappedBy = "store", cascade = ALL)
     private List<Item> items = new ArrayList<>();
 
-    @OneToMany(mappedBy = "store")
+    @OneToMany(mappedBy = "store", cascade = ALL)
     private List<Coupon> coupons = new ArrayList<>();
 
     @OneToMany(mappedBy = "store")
@@ -120,49 +122,8 @@ public class Store extends BaseTimeEntity {
     @OneToMany(mappedBy = "store")
     private List<Review> reviews = new ArrayList<>();
 
-    // 생성자 + 빌더
-    @Builder
-    public Store(Owner owner,
-                 StoreType storeType,
-                 String name,
-                 String imgUrl,
-                 String description,
-                 String extraBusinessDay,
-                 String phone,
-                 Point location,
-                 Boolean businessStatus,
-                 StoreStatus storeStatus,
-                 Boolean localCurrencyStatus,
-                 Boolean pickupStatus,
-                 Boolean deliveryStatus,
-                 Boolean pointPolicyStatus,
-                 Integer minimumOrderPrice,
-                 BigDecimal saveRate,
-                 String streetAddress,
-                 String detailedAddress
-    ) {
-        setOwner(owner);
-        this.storeType = storeType;
-        this.name = name;
-        this.imgUrl = imgUrl;
-        this.description = description;
-        this.extraBusinessDay = extraBusinessDay;
-        this.phone = phone;
-        this.location = location;
-        this.businessStatus = businessStatus;
-        this.storeStatus = storeStatus;
-        this.localCurrencyStatus = localCurrencyStatus;
-        this.pickupStatus = pickupStatus;
-        this.deliveryStatus = deliveryStatus;
-        this.pointPolicyStatus = pointPolicyStatus;
-        this.minimumOrderPrice = minimumOrderPrice;
-        this.saveRate = saveRate;
-        this.streetAddress = streetAddress;
-        this.detailedAddress = detailedAddress;
-    }
-
     // 연관 관계 편의 메서드
-    private void setOwner(Owner owner) {
+    public void setOwner(Owner owner) {
         if (this.owner != null) {
             this.owner.getStores().remove(this);
         }

--- a/src/main/java/com/sososhopping/server/entity/store/StoreBusinessDay.java
+++ b/src/main/java/com/sososhopping/server/entity/store/StoreBusinessDay.java
@@ -7,15 +7,18 @@ import javax.validation.constraints.NotNull;
 
 import static javax.persistence.FetchType.*;
 
+@Builder
 @Entity
 @Table(uniqueConstraints = {
         @UniqueConstraint(columnNames = {"store_id", "day"})
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class StoreBusinessDay {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "store_business_day_id")
     private Long id;
 
@@ -38,18 +41,8 @@ public class StoreBusinessDay {
     @Column(columnDefinition = "char")
     private String closeTime;
 
-    // 생성자 + 빌더
-    @Builder
-    public StoreBusinessDay(Store store, Day day, Boolean isOpen, String openTime, String closeTime) {
-        setStore(store);
-        this.day = day;
-        this.isOpen = isOpen;
-        this.openTime = openTime;
-        this.closeTime = closeTime;
-    }
-
     // 연관 관계 편의 메서드
-    private void setStore(Store store) {
+    public void setStore(Store store) {
         this.store = store;
         this.store.getStoreBusinessDays().add(this);
     }

--- a/src/main/java/com/sososhopping/server/entity/store/StoreImage.java
+++ b/src/main/java/com/sososhopping/server/entity/store/StoreImage.java
@@ -7,9 +7,11 @@ import javax.validation.constraints.NotNull;
 
 import static javax.persistence.FetchType.*;
 
+@Builder
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class StoreImage {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,15 +27,8 @@ public class StoreImage {
     @Column(length = 512)
     private String imgUrl;
 
-    // 생성자 + 빌더
-    @Builder
-    public StoreImage(Store store, String imgUrl) {
-        setStore(store);
-        this.imgUrl = imgUrl;
-    }
-
     // 연관 관계 편의 메서드
-    private void setStore(Store store) {
+    public void setStore(Store store) {
         this.store = store;
         this.store.getStoreImages().add(this);
     }

--- a/src/main/java/com/sososhopping/server/repository/coupon/CouponRepository.java
+++ b/src/main/java/com/sososhopping/server/repository/coupon/CouponRepository.java
@@ -1,0 +1,7 @@
+package com.sososhopping.server.repository.coupon;
+
+import com.sososhopping.server.entity.coupon.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/com/sososhopping/server/repository/store/ItemRepository.java
+++ b/src/main/java/com/sososhopping/server/repository/store/ItemRepository.java
@@ -1,0 +1,7 @@
+package com.sososhopping.server.repository.store;
+
+import com.sososhopping.server.entity.store.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/src/main/java/com/sososhopping/server/repository/store/UserStoreRepositoryImpl.java
+++ b/src/main/java/com/sososhopping/server/repository/store/UserStoreRepositoryImpl.java
@@ -1,11 +1,9 @@
 package com.sososhopping.server.repository.store;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.sososhopping.server.entity.store.Store;
 
 import javax.persistence.EntityManager;
 
-import java.util.Optional;
 
 public class UserStoreRepositoryImpl implements UserStoreRepository {
 

--- a/src/test/java/com/sososhopping/server/InitDataTest.java
+++ b/src/test/java/com/sososhopping/server/InitDataTest.java
@@ -1,5 +1,8 @@
 package com.sososhopping.server;
 
+import com.sososhopping.server.entity.coupon.Coupon;
+import com.sososhopping.server.entity.coupon.FixCoupon;
+import com.sososhopping.server.entity.coupon.RateCoupon;
 import com.sososhopping.server.entity.member.AccountStatus;
 import com.sososhopping.server.entity.member.Owner;
 import com.sososhopping.server.entity.store.*;
@@ -12,6 +15,8 @@ import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 /**
  * 테스트 데이터를 넣기 위한 파일입니다. @Rollback(false) 사용
@@ -24,9 +29,36 @@ class InitDataTest {
     private EntityManager em;
 
     @Test
+    @Rollback(false)
     void init() throws Exception {
 
         Store findStore = em.find(Store.class, 2L);
 
-     }
+        Coupon coupon = FixCoupon.builder()
+                .storeName("김씨네 야채가게")
+                .couponName("추석 할인 쿠폰")
+                .stockQuantity(100)
+                .couponCode("ABCDE12345")
+                .minimumOrderPrice(10000)
+                .startDate(LocalDateTime.now())
+                .dueDate(LocalDateTime.of(2021, 11, 30, 0, 0, 0))
+                .fixAmount(1000)
+                .build();
+
+        Coupon coupon2 = RateCoupon.builder()
+                .storeName("김씨네 야채가게")
+                .couponName("1주년 쿠폰")
+                .stockQuantity(200)
+                .couponCode("QWERT54321")
+                .minimumOrderPrice(0)
+                .startDate(LocalDateTime.now())
+                .dueDate(LocalDateTime.of(2021, 11, 30, 0, 0, 0))
+                .rateAmount(new BigDecimal(5.5))
+                .build();
+
+        coupon.setStore(findStore);
+        coupon2.setStore(findStore);
+
+        em.persist(findStore);
+    }
 }


### PR DESCRIPTION
상점 물품조회, 쿠폰조회 API  생성

Coupon 엔티티 3개 변경.
Coupon 엔티티에 coupon_type 필드 생성 + 생성자 생성
RateCoupon, FixCoupon은 생성자 + 빌더 사용. 빌더 내부에서 Coupon 생성자 호출.
추상클래스는 빌더를 못만들기 때문에 부모(추상)클래스의 자식에서 부모(추상)클래스의 필드를 빌드하려면 생성자를 호출해야 한다고함.